### PR TITLE
Fix: beginner devcontainer cannot install Playwright on Debian 11

### DIFF
--- a/.devcontainer/adventure-accessibility-nightmare_beginner/devcontainer.json
+++ b/.devcontainer/adventure-accessibility-nightmare_beginner/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "♿ The Accessibility Nightmare | 🟢 Beginner (The Initial Audit)",
-  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}/adventures/planned/adventure-accessibility-nightmare/beginner",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
## Problem

- Beginner level cannot start in a fresh Codespace
- `post-create.sh` runs `npx playwright install --with-deps chromium`, which fails: `libglx-mesa0` and `libxfont2` both 404 from the bullseye-security pool
- The script uses `set -e`, so it aborts there and no browser is ever installed
- Tests then fail with `Executable doesn't exist at .../chrome-headless-shell`, and the `npx playwright install` it suggests fails the same way
- Reproduced on a freshly pulled `base:bullseye`, on amd64 and arm64

## Fix

- `base:bullseye` → `base:bookworm`
- One word, one file

## Why not stay on Debian 11

- Playwright 1.62 refuses it outright: `does not support chromium on debian11-x64`
- The existing `^1.61.0` range picks up 1.62 on the next lockfile refresh, so any Debian 11 workaround is temporary

## Verified on bookworm, level otherwise unchanged

- `npm ci` and `playwright install --with-deps chromium` both succeed
- `chromium.executablePath()` resolves a real Chrome, so Lighthouse's `CHROME_PATH` works
- `npm run test:a11y` fails on `color-contrast`, `image-alt` and the keyboard test, which are the intentional bugs
- `npm run test:lighthouse` scores 80, as documented
- No change to `package.json`, lockfile, tests, `verify.sh`, or challenge content

## For reviewers

- Existing Codespaces for this level need a container rebuild
- Only devcontainer not on bullseye; the other 16 do not run a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
